### PR TITLE
fix: Ignore unparsable commits

### DIFF
--- a/lib/mix/tasks/git_ops.release.ex
+++ b/lib/mix/tasks/git_ops.release.ex
@@ -257,8 +257,6 @@ defmodule Mix.Tasks.GitOps.Release do
         commits_with_type(config_types, commits, text, log?)
 
       _ ->
-        error_if_log("Unparseable commit: #{text}", log?)
-
         []
     end
   end


### PR DESCRIPTION
### Contributor checklist
- [x] My commit messages follow the [Conventional Commit Message Format](https://gist.github.com/stephenparish/9941e89d80e2bc58a153#format-of-the-commit-message)
      For example: `fix: Multiply by appropriate coefficient`, or
      `feat(Calculator): Correctly preserve history`
      Any explanation or long form information in your commit message should be
      in a separate paragraph, separated by a blank line from the primary message
- [x] Bug fixes include regression tests
- [x] Features include unit/acceptance tests

